### PR TITLE
Fixed typo breaking skills

### DIFF
--- a/database/feh/artist.json
+++ b/database/feh/artist.json
@@ -27725,7 +27725,7 @@
   },
   "yoshio": {
     "heroes": {
-      "nnidhoggr2": "<:Blue_Beast:1124845338688233575>New Year N\u00ed\u00f0h\u00f6ggr",
+      "nidhoggr2": "<:Blue_Beast:1124845338688233575>New Year N\u00ed\u00f0h\u00f6ggr",
       "petra2": "<:Red_Bow:1124846280951218289>Summer Petra"
     },
     "name": "YOSHIO",

--- a/database/feh/va.json
+++ b/database/feh/va.json
@@ -29539,7 +29539,7 @@
   },
   "toyosakiaki": {
     "heroes": {
-      "nnidhoggr2": "<:Blue_Beast:1124845338688233575>New Year N\u00ed\u00f0h\u00f6ggr"
+      "nidhoggr2": "<:Blue_Beast:1124845338688233575>New Year N\u00ed\u00f0h\u00f6ggr"
     },
     "name": "Toyosaki Aki (\u8c4a\u5d0e\u611b\u751f)",
     "ALT_NAME": [


### PR DESCRIPTION
nidhoggr2 was incorrectly spelt "nnidhoggr2" preventing some skills from pulling up